### PR TITLE
2.1.1 - Public Accepted Brands

### DIFF
--- a/MundiAPI.Standard/Controllers/ChargesController.cs
+++ b/MundiAPI.Standard/Controllers/ChargesController.cs
@@ -88,7 +88,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -154,7 +154,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -225,7 +225,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -334,7 +334,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -400,7 +400,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -469,7 +469,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -536,7 +536,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -607,7 +607,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -678,7 +678,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -749,7 +749,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -812,7 +812,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -890,7 +890,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -958,7 +958,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/CustomersController.cs
+++ b/MundiAPI.Standard/Controllers/CustomersController.cs
@@ -92,7 +92,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -163,7 +163,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -230,7 +230,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -292,7 +292,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -365,7 +365,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -430,7 +430,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -495,7 +495,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -561,7 +561,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -633,7 +633,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -692,7 +692,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -774,7 +774,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -852,7 +852,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -918,7 +918,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -990,7 +990,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1068,7 +1068,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1146,7 +1146,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1213,7 +1213,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1303,7 +1303,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1370,7 +1370,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1437,7 +1437,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1507,7 +1507,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/InvoicesController.cs
+++ b/MundiAPI.Standard/Controllers/InvoicesController.cs
@@ -103,7 +103,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -170,7 +170,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -236,7 +236,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -303,7 +303,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -369,7 +369,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -438,7 +438,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -553,7 +553,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/OrdersController.cs
+++ b/MundiAPI.Standard/Controllers/OrdersController.cs
@@ -92,7 +92,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -161,7 +161,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -228,7 +228,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -327,7 +327,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -393,7 +393,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -465,7 +465,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -528,7 +528,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -586,7 +586,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -656,7 +656,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -733,7 +733,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }

--- a/MundiAPI.Standard/Controllers/PlansController.cs
+++ b/MundiAPI.Standard/Controllers/PlansController.cs
@@ -103,7 +103,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -174,7 +174,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -273,7 +273,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -335,7 +335,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -401,7 +401,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -472,7 +472,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -535,7 +535,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -607,7 +607,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -673,7 +673,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -737,7 +737,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };

--- a/MundiAPI.Standard/Controllers/RecipientsController.cs
+++ b/MundiAPI.Standard/Controllers/RecipientsController.cs
@@ -92,7 +92,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -163,7 +163,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -233,7 +233,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -298,7 +298,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -360,7 +360,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -469,7 +469,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -535,7 +535,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -606,7 +606,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -673,7 +673,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -738,7 +738,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -832,7 +832,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -898,7 +898,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -961,7 +961,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1032,7 +1032,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1110,7 +1110,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1174,7 +1174,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" }
             };
@@ -1243,7 +1243,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1337,7 +1337,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1403,7 +1403,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1470,7 +1470,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/SellersController.cs
+++ b/MundiAPI.Standard/Controllers/SellersController.cs
@@ -84,7 +84,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -155,7 +155,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -264,7 +264,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -330,7 +330,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -399,7 +399,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -462,7 +462,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/SubscriptionsController.cs
+++ b/MundiAPI.Standard/Controllers/SubscriptionsController.cs
@@ -92,7 +92,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -162,7 +162,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -240,7 +240,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -307,7 +307,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -379,7 +379,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -445,7 +445,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -511,7 +511,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -582,7 +582,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -652,7 +652,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -706,7 +706,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -805,7 +805,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -869,7 +869,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -947,7 +947,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1019,7 +1019,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1085,7 +1085,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1152,7 +1152,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1226,7 +1226,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1303,7 +1303,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1374,7 +1374,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1483,7 +1483,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1549,7 +1549,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1620,7 +1620,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1698,7 +1698,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1760,7 +1760,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -1826,7 +1826,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -1898,7 +1898,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "idempotency-key", idempotencyKey }
             };
@@ -1965,7 +1965,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -2036,7 +2036,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -2107,7 +2107,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -2185,7 +2185,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -2251,7 +2251,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -2375,7 +2375,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -2440,7 +2440,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -2549,7 +2549,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -2615,7 +2615,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -2685,7 +2685,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/TokensController.cs
+++ b/MundiAPI.Standard/Controllers/TokensController.cs
@@ -92,7 +92,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" },
                 { "idempotency-key", idempotencyKey }
@@ -162,7 +162,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/TransactionsController.cs
+++ b/MundiAPI.Standard/Controllers/TransactionsController.cs
@@ -88,7 +88,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Controllers/TransfersController.cs
+++ b/MundiAPI.Standard/Controllers/TransfersController.cs
@@ -82,7 +82,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" },
                 { "content-type", "application/json; charset=utf-8" }
             };
@@ -148,7 +148,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 
@@ -202,7 +202,7 @@ namespace MundiAPI.Standard.Controllers
             //append request with appropriate headers and parameters
             var _headers = new Dictionary<string,string>()
             {
-                { "user-agent", "MundiSDK - DotNet 2.1.0" },
+                { "user-agent", "MundiSDK - DotNet 2.1.1" },
                 { "accept", "application/json" }
             };
 

--- a/MundiAPI.Standard/Models/CreateCheckoutPaymentRequest.cs
+++ b/MundiAPI.Standard/Models/CreateCheckoutPaymentRequest.cs
@@ -35,6 +35,7 @@ namespace MundiAPI.Standard.Models
         private bool billingAddressEditable;
         private Models.CreateAddressRequest billingAddress;
         private Models.CreateCheckoutBankTransferRequest bankTransfer;
+        private List<string> acceptedBrands;
 
         /// <summary>
         /// Accepted Payment Methods
@@ -271,6 +272,23 @@ namespace MundiAPI.Standard.Models
             {
                 this.bankTransfer = value;
                 onPropertyChanged("BankTransfer");
+            }
+        }
+
+        /// <summary>
+        /// Accepted Brands
+        /// </summary>
+        [JsonProperty("accepted_brands")]
+        public List<string> AcceptedBrands 
+        { 
+            get 
+            {
+                return this.acceptedBrands; 
+            } 
+            set 
+            {
+                this.acceptedBrands = value;
+                onPropertyChanged("AcceptedBrands");
             }
         }
     }

--- a/MundiAPI.Standard/Models/GetCheckoutPaymentResponse.cs
+++ b/MundiAPI.Standard/Models/GetCheckoutPaymentResponse.cs
@@ -46,6 +46,7 @@ namespace MundiAPI.Standard.Models
         private string currency;
         private Models.GetCheckoutDebitCardPaymentResponse debitCard;
         private Models.GetCheckoutBankTransferPaymentResponse bankTransfer;
+        private List<string> acceptedBrands;
 
         /// <summary>
         /// TODO: Write general description for this method
@@ -474,6 +475,23 @@ namespace MundiAPI.Standard.Models
             {
                 this.bankTransfer = value;
                 onPropertyChanged("BankTransfer");
+            }
+        }
+
+        /// <summary>
+        /// Accepted Brands
+        /// </summary>
+        [JsonProperty("accepted_brands")]
+        public List<string> AcceptedBrands 
+        { 
+            get 
+            {
+                return this.acceptedBrands; 
+            } 
+            set 
+            {
+                this.acceptedBrands = value;
+                onPropertyChanged("AcceptedBrands");
             }
         }
     }

--- a/MundiAPI.Standard/MundiAPI.Standard.csproj
+++ b/MundiAPI.Standard/MundiAPI.Standard.csproj
@@ -9,13 +9,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AssemblyName>MundiAPI.Standard</AssemblyName>
-    <Version>2.1.0.0</Version>
+    <Version>2.1.1.0</Version>
     <Authors></Authors>
     <Company></Company>
     <Product>MundiAPI.Standard</Product>
     <Copyright>Copyright ©  2017</Copyright>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
     <Description>Automatically generated using APIMatic.</Description>
   </PropertyGroup>
 

--- a/MundiAPI.Standard/MundiAPI.Standard.nuspec
+++ b/MundiAPI.Standard/MundiAPI.Standard.nuspec
@@ -7,7 +7,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>MundiAPI.Standard</id>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <title>MundiAPI.Standard</title>
     <authors>APIMATIC SDK Generator</authors>
     <iconUrl>https://nuget.org/Content/Images/packageDefaultIcon-50x50.png</iconUrl>

--- a/MundiAPI.sln
+++ b/MundiAPI.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MundiAPI.Standard", "MundiAPI.Standard/MundiAPI.Standard.csproj", "{ee1b416c-fbe1-4de7-a638-5adf95f34d8e}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MundiAPI.Standard", "MundiAPI.Standard/MundiAPI.Standard.csproj", "{e04ff51b-61d0-410c-9cbb-e3a71c694293}"
 EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
         Release|Any CPU = Release|Any CPU
     EndGlobalSection
     GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {ee1b416c-fbe1-4de7-a638-5adf95f34d8e}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-        {ee1b416c-fbe1-4de7-a638-5adf95f34d8e}.Debug|Any CPU.Build.0 = Debug|Any CPU
-        {ee1b416c-fbe1-4de7-a638-5adf95f34d8e}.Release|Any CPU.ActiveCfg = Release|Any CPU
-        {ee1b416c-fbe1-4de7-a638-5adf95f34d8e}.Release|Any CPU.Build.0 = Release|Any CPU
+        {e04ff51b-61d0-410c-9cbb-e3a71c694293}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {e04ff51b-61d0-410c-9cbb-e3a71c694293}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {e04ff51b-61d0-410c-9cbb-e3a71c694293}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {e04ff51b-61d0-410c-9cbb-e3a71c694293}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+### DEPRECATED | CHECK NEW VERSION > https://github.com/pagarme/pagarme-core-api-dotnet-standard
+
+# Mundipagg agora é Pagar.me
+
+Buscando trazer a melhor experiência para os nossos clientes, a Mundipagg agora é parte do Pagar.me.
+
+Somamos nossas funcionalidades e agora você tem acesso a uma plataforma financeira completa, que oferece o melhor das duas soluções em uma experiência unificada.
+
+Você pode customizar nossos produtos e serviços da forma que for melhor para o seu e-commerce. Ficou curioso para saber o que muda? Preparamos um FAQ completo explicando tudo.
+
+[Saiba mais](https://mundipagg.zendesk.com/hc/pt-br/categories/4404432249876-Incorpora%C3%A7%C3%A3o-Mundipagg-pelo-Pagar-me)
+
+-----------------------------------------------------------------------------------------------------------------------------
+
 # Getting started
 
 Mundipagg API

--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
-### DEPRECATED | CHECK NEW VERSION > https://github.com/pagarme/pagarme-core-api-dotnet-standard
-
-# Mundipagg agora é Pagar.me
-
-Buscando trazer a melhor experiência para os nossos clientes, a Mundipagg agora é parte do Pagar.me.
-
-Somamos nossas funcionalidades e agora você tem acesso a uma plataforma financeira completa, que oferece o melhor das duas soluções em uma experiência unificada.
-
-Você pode customizar nossos produtos e serviços da forma que for melhor para o seu e-commerce. Ficou curioso para saber o que muda? Preparamos um FAQ completo explicando tudo.
-
-[Saiba mais](https://mundipagg.zendesk.com/hc/pt-br/categories/4404432249876-Incorpora%C3%A7%C3%A3o-Mundipagg-pelo-Pagar-me)
-
------------------------------------------------------------------------------------------------------------------------------
-
 # Getting started
 
 Mundipagg API
@@ -259,8 +245,8 @@ Task<Models.ListAddressesResponse> GetAddresses(string customerId, int? page = n
 
 ```csharp
 string customerId = "customer_id";
-int? page = 209;
-int? size = 209;
+int? page = 38;
+int? size = 38;
 
 Models.ListAddressesResponse result = await customers.GetAddresses(customerId, page, size);
 
@@ -469,8 +455,8 @@ Task<Models.ListAccessTokensResponse> GetAccessTokens(string customerId, int? pa
 
 ```csharp
 string customerId = "customer_id";
-int? page = 209;
-int? size = 209;
+int? page = 38;
+int? size = 38;
 
 Models.ListAccessTokensResponse result = await customers.GetAccessTokens(customerId, page, size);
 
@@ -595,8 +581,8 @@ Task<Models.ListCardsResponse> GetCards(string customerId, int? page = null, int
 
 ```csharp
 string customerId = "customer_id";
-int? page = 209;
-int? size = 209;
+int? page = 38;
+int? size = 38;
 
 Models.ListCardsResponse result = await customers.GetCards(customerId, page, size);
 
@@ -897,8 +883,8 @@ Task<Models.ListChargesResponse> GetCharges(
 #### Example Usage
 
 ```csharp
-int? page = 209;
-int? size = 209;
+int? page = 38;
+int? size = 38;
 string code = "code";
 string status = "status";
 string paymentMethod = "payment_method";
@@ -1140,8 +1126,8 @@ Task<Models.ListChargeTransactionsResponse> GetChargeTransactions(string chargeI
 
 ```csharp
 string chargeId = "charge_id";
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 
 Models.ListChargeTransactionsResponse result = await charges.GetChargeTransactions(chargeId, page, size);
 
@@ -1298,8 +1284,8 @@ Task<Models.ListRecipientResponse> GetRecipients(int? page = null, int? size = n
 #### Example Usage
 
 ```csharp
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 
 Models.ListRecipientResponse result = await recipients.GetRecipients(page, size);
 
@@ -1369,8 +1355,8 @@ Task<Models.ListAnticipationResponse> GetAnticipations(
 
 ```csharp
 string recipientId = "recipient_id";
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 string status = "status";
 string timeframe = "timeframe";
 DateTime? paymentDateSince = DateTime.Now();
@@ -1528,8 +1514,8 @@ Task<Models.ListTransferResponse> GetTransfers(
 
 ```csharp
 string recipientId = "recipient_id";
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 string status = "status";
 DateTime? createdSince = DateTime.Now();
 DateTime? createdUntil = DateTime.Now();
@@ -1744,8 +1730,8 @@ Task<Models.ListWithdrawals> GetWithdrawals(
 
 ```csharp
 string recipientId = "recipient_id";
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 string status = "status";
 DateTime? createdSince = DateTime.Now();
 DateTime? createdUntil = DateTime.Now();
@@ -2155,8 +2141,8 @@ Task<Models.GetUsagesDetailsResponse> GetUsagesDetails(
 ```csharp
 string subscriptionId = "subscription_id";
 string cycleId = "cycle_id";
-int? size = 209;
-int? page = 209;
+int? size = 80;
+int? page = 80;
 string itemId = "item_id";
 string mgroup = "group";
 
@@ -2339,8 +2325,8 @@ Task<Models.ListIncrementsResponse> GetIncrements(string subscriptionId, int? pa
 
 ```csharp
 string subscriptionId = "subscription_id";
-int? page = 209;
-int? size = 209;
+int? page = 80;
+int? size = 80;
 
 Models.ListIncrementsResponse result = await subscriptions.GetIncrements(subscriptionId, page, size);
 
@@ -2449,8 +2435,8 @@ Task<Models.ListUsagesResponse> GetUsages(
 ```csharp
 string subscriptionId = "subscription_id";
 string itemId = "item_id";
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string code = "code";
 string mgroup = "group";
 DateTime? usedSince = DateTime.Now();
@@ -2749,8 +2735,8 @@ Task<Models.ListDiscountsResponse> GetDiscounts(string subscriptionId, int page,
 
 ```csharp
 string subscriptionId = "subscription_id";
-int page = 46;
-int size = 46;
+int page = 80;
+int size = 80;
 
 Models.ListDiscountsResponse result = await subscriptions.GetDiscounts(subscriptionId, page, size);
 
@@ -2829,8 +2815,8 @@ Task<Models.ListSubscriptionsResponse> GetSubscriptions(
 #### Example Usage
 
 ```csharp
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string code = "code";
 string billingType = "billing_type";
 string customerId = "customer_id";
@@ -2912,8 +2898,8 @@ Task<Models.ListSubscriptionItemsResponse> GetSubscriptionItems(
 
 ```csharp
 string subscriptionId = "subscription_id";
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string name = "name";
 string code = "code";
 string status = "status";
@@ -3212,8 +3198,8 @@ Task<Models.ListInvoicesResponse> GetInvoices(
 #### Example Usage
 
 ```csharp
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string code = "code";
 string customerId = "customer_id";
 string subscriptionId = "subscription_id";
@@ -3361,8 +3347,8 @@ Task<Models.ListOrderResponse> GetOrders(
 #### Example Usage
 
 ```csharp
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string code = "code";
 string status = "status";
 DateTime? createdSince = DateTime.Now();
@@ -3658,8 +3644,8 @@ Task<Models.ListSellerResponse> GetSellers(
 #### Example Usage
 
 ```csharp
-int? page = 46;
-int? size = 46;
+int? page = 80;
+int? size = 80;
 string name = "name";
 string document = "document";
 string code = "code";
@@ -3941,8 +3927,8 @@ Task<Models.ListPlansResponse> GetPlans(
 #### Example Usage
 
 ```csharp
-int? page = 46;
-int? size = 46;
+int? page = 243;
+int? size = 243;
 string name = "name";
 string status = "status";
 string billingType = "billing_type";


### PR DESCRIPTION
Chegou ao nosso conhecimento que, quando o cliente estava fazendo checkout via sdk, ele recebia  o parâmetro "Accepted_Brands".  Porem ele  tinha a necessidade de restringir qualquer tipo de acesso a bandeiras de cartão. 
